### PR TITLE
feat(auth): implement register & login with email/phone

### DIFF
--- a/.dockerignore 
+++ b/.dockerignore 
@@ -1,0 +1,20 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+
+# Docker
+Dockerfile
+.dockerignore
+
+# IDE
+.idea/
+.vscode/

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,43 +1,43 @@
 # alembic/env.py
-import os, sys
+import os
+import sys
 from logging.config import fileConfig
+
 from alembic import context
 from sqlalchemy import create_engine, pool
 
+# --- Path & dotenv ------------------------------------------------------------
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(BASE_DIR)
 
 from dotenv import load_dotenv
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
-# 1) Import Base lebih dulu
+# --- Import Base & models (agar terdaftar ke Base.metadata) -------------------
 from src.database import Base
-
-# 2) Import SEMUA modul yang mendefinisikan model (agar kelas2 model terdaftar ke Base.metadata)
 from src.auth import models as auth_models  # noqa: F401
-# kalau ada model lain:
+# Jika ada model lain, import juga (biarkan tak terpakai; penting untuk discovery):
 # from src.users import models as users_models  # noqa: F401
 # from src.files import models as files_models  # noqa: F401
 
-# 3) Baru set metadata untuk Alembic
+# --- Alembic config ------------------------------------------------------------
 config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
 
-# 4) Ambil DATABASE_URL
+# --- Only use DATABASE_URL (tanpa fallback) -----------------------------------
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
-    host = os.getenv("POSTGRES_HOST", "db")
-    user = os.getenv("POSTGRES_USER", "postgres")
-    pwd = os.getenv("POSTGRES_PASSWORD", "root")
-    dbname = os.getenv("POSTGRES_DB", "tutuplapak_db")
-    DATABASE_URL = f"postgresql+psycopg2://{user}:{pwd}@{host}:5432/{dbname}"
-
-print(f"DEBUG Alembic DATABASE_URL: {DATABASE_URL}")
+    raise RuntimeError(
+        "DATABASE_URL is not set. Define it in .env (e.g. "
+        "'postgresql+psycopg2://postgres:root@db:5432/tutuplapak_db')."
+    )
+# print(f"DEBUG Alembic DATABASE_URL: {DATABASE_URL}")  # optional
 
 def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
     context.configure(
         url=DATABASE_URL,
         target_metadata=target_metadata,
@@ -48,7 +48,12 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 def run_migrations_online() -> None:
-    connectable = create_engine(DATABASE_URL, poolclass=pool.NullPool, pool_pre_ping=True)
+    """Run migrations in 'online' mode."""
+    connectable = create_engine(
+        DATABASE_URL,
+        poolclass=pool.NullPool,
+        pool_pre_ping=True,
+    )
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,35 @@
 version: '3.8'
 
 services:
+  db:
+    image: postgres:16
+    env_file:
+      - ./.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-tutuplapak_db}"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+    # Optional: expose DB if you want external clients
+    # ports:
+    #   - "5432:5432"
+
   app:
     build: .
+    env_file:
+      - ./.env
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - "8000:8000"
-    environment:
-      - DATABASE_URL=${DATABASE_URL}
     volumes:
-      - .:/app
+      - ./src:/app/src
+      - ./alembic:/app/alembic
+    # Only include this if your Dockerfile doesn't already run uvicorn
+    # command: uvicorn src.main:app --host 0.0.0.0 --port 8000
+
+volumes:
+  pgdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ python-multipart
 sqlalchemy
 asyncpg
 alembic
+cuid2
+psycopg2-binary
+pydantic-settings
+PyJWT
+pydantic[email]

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder for API endpoints

--- a/src/auth/config.py
+++ b/src/auth/config.py
@@ -1,0 +1,17 @@
+#src/auth/config.py
+import secrets
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    # Variabel ini akan dibaca dari .env
+    DATABASE_URL: str
+    SECRET_KEY: str
+
+    # Variabel ini bisa kita beri nilai default di sini
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+# Buat satu instance 'settings' yang akan kita import di file lain
+settings = Settings()

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -1,0 +1,40 @@
+# src/auth/models.py
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import String, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from src.database import Base
+from cuid2 import cuid_wrapper
+
+generate_cuid = cuid_wrapper()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(
+        String(255),
+        primary_key=True,
+        default=generate_cuid,
+    )
+
+    # email boleh kosong kalau daftar via phone
+    email: Mapped[Optional[str]] = mapped_column(
+        String(255), unique=True, index=True, nullable=True
+    )
+
+    phone: Mapped[Optional[str]] = mapped_column(
+        String(50), unique=True, index=True, nullable=True
+    )
+
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )

--- a/src/auth/router.py
+++ b/src/auth/router.py
@@ -34,15 +34,27 @@ def register_by_phone(user_data: schemas.UserCreatePhone, db: Session = Depends(
     token = service.create_access_token(data={"sub": str(new_user.id)})
     return {"email": new_user.email or "", "phone": new_user.phone or "", "token": token}
 
-# @router.post("/login/email", response_model=schemas.TokenResponse)
-# def login_by_email(user_data: schemas.UserLogin, db: Session = Depends(get_db)):
-#     user = service.authenticate_user(db, user_data=user_data)
-#     if not user:
-#         raise HTTPException(
-#             status_code=status.HTTP_401_UNAUTHORIZED,
-#             detail="Incorrect email or password",
-#             headers={"WWW-Authenticate": "Bearer"},
-#         )
-#     token = service.create_access_token(data={"sub": str(user.id)})
-#     return {"email": user.email or "", "phone": user.phone or "", "token": token}
+@router.post("/login/email", response_model=schemas.TokenResponse)
+def login_by_email(user_data: schemas.UserLogin, db: Session = Depends(get_db)):
+    user = service.authenticate_user(db, user_data=user_data)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    token = service.create_access_token(data={"sub": str(user.id)})
+    return {"email": user.email or "", "phone": user.phone or "", "token": token}
+
+@router.post("/login/phone", response_model=schemas.TokenResponse)
+def login_by_phone(user_data: schemas.UserLoginPhone, db: Session = Depends(get_db)):
+    user = service.authenticate_user_by_phone(db, phone=user_data.phone, password=user_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="phone is not found or password incorrect",
+        )
+    token = service.create_access_token(data={"sub": str(user.id)})
+    return {"email": user.email or "", "phone": user.phone or "", "token": token}
+
     

--- a/src/auth/router.py
+++ b/src/auth/router.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from src.database import get_db
+from . import schemas, service
+
+# Prefix hanya domain, tanpa versi
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+@router.post("/register/email", response_model=schemas.TokenResponse, status_code=status.HTTP_201_CREATED)
+def register_by_email(user_data: schemas.UserCreate, db: Session = Depends(get_db)):
+    if service.get_user_by_email(db, email=user_data.email):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email is exist")
+
+    try:
+        new_user = service.create_user(db=db, user_data=user_data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email is exist")
+
+    token = service.create_access_token(data={"sub": str(new_user.id)})
+    return {"email": new_user.email or "", "phone": new_user.phone or "", "token": token}
+
+@router.post("/register/phone", response_model=schemas.TokenResponse, status_code=status.HTTP_201_CREATED)
+def register_by_phone(user_data: schemas.UserCreatePhone, db: Session = Depends(get_db)):
+    if service.get_user_by_phone(db, phone=user_data.phone):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="phone is exist")
+
+    try:
+        new_user = service.create_user(db=db, user_data=user_data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="phone is exist")
+
+    token = service.create_access_token(data={"sub": str(new_user.id)})
+    return {"email": new_user.email or "", "phone": new_user.phone or "", "token": token}
+
+# @router.post("/login/email", response_model=schemas.TokenResponse)
+# def login_by_email(user_data: schemas.UserLogin, db: Session = Depends(get_db)):
+#     user = service.authenticate_user(db, user_data=user_data)
+#     if not user:
+#         raise HTTPException(
+#             status_code=status.HTTP_401_UNAUTHORIZED,
+#             detail="Incorrect email or password",
+#             headers={"WWW-Authenticate": "Bearer"},
+#         )
+#     token = service.create_access_token(data={"sub": str(user.id)})
+#     return {"email": user.email or "", "phone": user.phone or "", "token": token}
+    

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -12,6 +12,10 @@ class UserCreatePhone(BaseModel):
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
+    
+class UserLoginPhone(BaseModel):
+    phone: str = Field(..., pattern=r"^\+[1-9]\d{1,14}$")
+    password: str
 
 # Responses (spec minta string kosong ketika tidak ada)
 class UserOut(BaseModel):

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, EmailStr, constr, Field
+
+# Request bodies
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: constr(min_length=8, max_length=32)
+
+class UserCreatePhone(BaseModel):
+    phone: str = Field(..., pattern=r"^\+[1-9]\d{1,14}$")
+    password: constr(min_length=8, max_length=32)
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+# Responses (spec minta string kosong ketika tidak ada)
+class UserOut(BaseModel):
+    email: str = ""
+    phone: str = ""
+    class Config:
+        from_attributes = True
+
+class TokenResponse(BaseModel):
+    email: str = ""
+    phone: str = ""
+    token: str

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -50,6 +50,14 @@ def authenticate_user(db: Session, user_data: schemas.UserLogin):
         return None
     return user
 
+def authenticate_user_by_phone(db: Session, phone: str, password: str):
+    user = get_user_by_phone(db, phone=phone)
+    if not user:
+        return None
+    if not verify_password(password, user.password_hash):
+        return None
+    return user
+
 # Opsi B (alternatif): jika mau dukung phone
 # def authenticate_user(db: Session, email: str | None = None, phone: str | None = None, password: str = ""):
 #     user = get_user_by_email(db, email) if email else get_user_by_phone(db, phone) if phone else None

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime, timedelta, timezone
+import jwt
+
+from . import models, schemas
+from .utils import hash_password, verify_password
+from .config import settings
+
+def get_user_by_email(db: Session, email: str):
+    return db.query(models.User).filter(models.User.email == email).first()
+
+def get_user_by_phone(db: Session, phone: str):
+    return db.query(models.User).filter(models.User.phone == phone).first()
+
+def create_access_token(data: dict):
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+    )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(
+        to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+    )
+    return encoded_jwt
+
+def create_user(db: Session, user_data: schemas.UserCreate | schemas.UserCreatePhone):
+    hashed_password = hash_password(user_data.password)
+    user_dict = user_data.model_dump()
+    user_dict.pop("password")
+
+    db_user = models.User(**user_dict, password_hash=hashed_password)
+    db.add(db_user)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(db_user)
+    return db_user
+
+# Opsi A: Login via email saja (seperti punyamu)
+def authenticate_user(db: Session, user_data: schemas.UserLogin):
+    user = get_user_by_email(db, email=user_data.email)
+    if not user:
+        return None
+    if not verify_password(user_data.password, user.password_hash):
+        return None
+    return user
+
+# Opsi B (alternatif): jika mau dukung phone
+# def authenticate_user(db: Session, email: str | None = None, phone: str | None = None, password: str = ""):
+#     user = get_user_by_email(db, email) if email else get_user_by_phone(db, phone) if phone else None
+#     if not user or not verify_password(password, user.password_hash):
+#         return None
+#     return user

--- a/src/auth/utils.py
+++ b/src/auth/utils.py
@@ -1,0 +1,12 @@
+from passlib.context import CryptContext
+
+# Membuat konteks untuk hashing, kita pakai algoritma bcrypt
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Fungsi untuk memverifikasi password asli dengan hash di database."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+def hash_password(password: str) -> str:
+    """Fungsi untuk membuat hash dari password."""
+    return pwd_context.hash(password)

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,17 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+from src.auth.config import settings
+
+# Langsung gunakan DATABASE_URL dari settings
+engine = create_engine(settings.DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/files/__init__.py
+++ b/src/files/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder for API endpoints

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,15 @@
 from fastapi import FastAPI
+from src.auth.router import router as auth_router
 
-app = FastAPI(title="TutupLapak", version="1.0.0")
+app = FastAPI(
+    title="TutupLapak API",
+    version="1.0.0",
+    description="TutupLapak API - Authentication, Users, Files service"
+)
 
-# TODO: Add feature routers here
-# from .auth.router import auth_router
-# from .users.router import users_router
-# from .files.router import files_router
-
-# app.include_router(auth_router, prefix="/auth", tags=["Authentication"])
-# app.include_router(users_router, prefix="/users", tags=["Users"])
-# app.include_router(files_router, prefix="/files", tags=["Files"])
+# Global versioning di sini
+app.include_router(auth_router, prefix="/v1")
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to TutupLapak"}
+    return {"message": "Welcome to TutupLapak API!"}

--- a/src/users/__init__.py
+++ b/src/users/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder for API endpoints


### PR DESCRIPTION
### What I did
- Implement user registration via email and phone
- Add JWT token generation on register
- Add login by phone (email login already exists)
- Adjust response model to follow API contract (empty string for unused field)
- Update Alembic migration to create `users` table with email & phone unique

### How to test
1. Run `docker compose up -d`
2. Open Swagger at http://localhost:8000/docs
3. Test:
   - POST /v1/auth/register/email
   - POST /v1/auth/register/phone
   - POST /v1/auth/login/email
   - POST /v1/auth/login/phone

### Expected result
- Register returns 201 with token
- Login returns 200 with token
- Duplicate email/phone → 409 Conflict
- Wrong payload format → 422 Validation error