### PR TITLE
feat(user): add profile endpoints (get, put, link phone/email)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,43 +1,44 @@
 # alembic/env.py
-import os, sys
+import os
+import sys
 from logging.config import fileConfig
+
 from alembic import context
 from sqlalchemy import create_engine, pool
 
+# --- Path & dotenv ------------------------------------------------------------
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(BASE_DIR)
 
 from dotenv import load_dotenv
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
-# 1) Import Base lebih dulu
+# --- Import Base & models (agar terdaftar ke Base.metadata) -------------------
 from src.database import Base
-
-# 2) Import SEMUA modul yang mendefinisikan model (agar kelas2 model terdaftar ke Base.metadata)
 from src.auth import models as auth_models  # noqa: F401
-# kalau ada model lain:
+from src.users import models as user_models  # noqa: F401   <-- add this line
+# Jika ada model lain, import juga (biarkan tak terpakai; penting untuk discovery):
 # from src.users import models as users_models  # noqa: F401
 # from src.files import models as files_models  # noqa: F401
 
-# 3) Baru set metadata untuk Alembic
+# --- Alembic config ------------------------------------------------------------
 config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
 
-# 4) Ambil DATABASE_URL
+# --- Only use DATABASE_URL (tanpa fallback) -----------------------------------
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
-    host = os.getenv("POSTGRES_HOST", "db")
-    user = os.getenv("POSTGRES_USER", "postgres")
-    pwd = os.getenv("POSTGRES_PASSWORD", "root")
-    dbname = os.getenv("POSTGRES_DB", "tutuplapak_db")
-    DATABASE_URL = f"postgresql+psycopg2://{user}:{pwd}@{host}:5432/{dbname}"
-
-print(f"DEBUG Alembic DATABASE_URL: {DATABASE_URL}")
+    raise RuntimeError(
+        "DATABASE_URL is not set. Define it in .env (e.g. "
+        "'postgresql+psycopg2://postgres:root@db:5432/tutuplapak_db')."
+    )
+# print(f"DEBUG Alembic DATABASE_URL: {DATABASE_URL}")  # optional
 
 def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
     context.configure(
         url=DATABASE_URL,
         target_metadata=target_metadata,
@@ -48,7 +49,12 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 def run_migrations_online() -> None:
-    connectable = create_engine(DATABASE_URL, poolclass=pool.NullPool, pool_pre_ping=True)
+    """Run migrations in 'online' mode."""
+    connectable = create_engine(
+        DATABASE_URL,
+        poolclass=pool.NullPool,
+        pool_pre_ping=True,
+    )
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -1,0 +1,34 @@
+# src/auth/dependencies.py
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+import jwt
+
+from src.database import get_db
+from .config import settings
+from . import models
+
+# Tambahkan security scheme HTTPBearer
+security = HTTPBearer()
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+) -> models.User:
+    token = credentials.credentials  # <-- otomatis ambil setelah "Bearer "
+
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        user_id = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired")
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Token")
+
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -29,6 +29,16 @@ class User(Base):
 
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
 
+    # Placeholder untuk file_id (nanti dihubungkan ke tabel files)
+    file_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, index=True
+    )
+
+    # ✅ Tambahkan kolom bank account di dalam class
+    bank_account_name: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    bank_account_holder: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    bank_account_number: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -1,50 +1,21 @@
 # src/auth/models.py
 from datetime import datetime
 from typing import Optional
-
 from sqlalchemy import String, DateTime, func
 from sqlalchemy.orm import Mapped, mapped_column
 from src.database import Base
 from cuid2 import cuid_wrapper
 
-generate_cuid = cuid_wrapper()
+cuid = cuid_wrapper()
 
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[str] = mapped_column(
-        String(255),
-        primary_key=True,
-        default=generate_cuid,
-    )
-
-    # email boleh kosong kalau daftar via phone
-    email: Mapped[Optional[str]] = mapped_column(
-        String(255), unique=True, index=True, nullable=True
-    )
-
-    phone: Mapped[Optional[str]] = mapped_column(
-        String(50), unique=True, index=True, nullable=True
-    )
-
+    id: Mapped[str] = mapped_column(String(255), primary_key=True, default=cuid)
+    email: Mapped[Optional[str]] = mapped_column(String(255), unique=True, index=True, nullable=True)
+    phone: Mapped[Optional[str]] = mapped_column(String(50), unique=True, index=True, nullable=True)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
 
-    # Placeholder untuk file_id (nanti dihubungkan ke tabel files)
-    file_id: Mapped[Optional[str]] = mapped_column(
-        String(255), nullable=True, index=True
-    )
-
-    # ✅ Tambahkan kolom bank account di dalam class
-    bank_account_name: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
-    bank_account_holder: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
-    bank_account_number: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
-
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now(), nullable=True
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True)

--- a/src/files/models.py
+++ b/src/files/models.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from sqlalchemy import String, DateTime, func, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from cuid2 import cuid_wrapper
+from src.database import Base
+
+generate_cuid = cuid_wrapper()
+
+class File(Base):
+    __tablename__ = "files"
+
+    id: Mapped[str] = mapped_column(String(255), primary_key=True, default=generate_cuid)
+    uri: Mapped[str] = mapped_column(String(500), nullable=False)
+    thumbnail_uri: Mapped[str] = mapped_column(String(500), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,16 @@
+# src/main.py
 from fastapi import FastAPI
-from src.auth.router import router as auth_router
+from src.auth.router import router as auth_router  # has prefix="/v1"
+from src.users.router import router as users_router # has prefix="/v1"
 
 app = FastAPI(
     title="TutupLapak API",
     version="1.0.0",
-    description="TutupLapak API - Authentication, Users, Files service"
+    description="TutupLapak API - Authentication, Users, Files service",
 )
 
-# Global versioning di sini
-app.include_router(auth_router, prefix="/v1")
+app.include_router(auth_router)   # no extra prefix here
+app.include_router(users_router)  # no extra prefix here
 
 @app.get("/")
 def read_root():

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1,0 +1,34 @@
+# src/users/models.py
+from datetime import datetime
+from typing import Optional
+from sqlalchemy import String, DateTime, func, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from src.database import Base
+from cuid2 import cuid_wrapper
+
+cuid = cuid_wrapper()
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    id: Mapped[str] = mapped_column(String(255), primary_key=True, default=cuid)
+
+    # One-to-one dengan users: satu user satu profile
+    user_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        unique=True,          # enforce 1-1
+    )
+
+    # kolom profil
+    file_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)
+    bank_account_name: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    bank_account_holder: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    bank_account_number: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    __table_args__ = (UniqueConstraint("user_id", name="uq_profiles_user_id"),)

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -1,86 +1,77 @@
-# src/users/router.py
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
-
 from src.database import get_db
 from src.auth.dependencies import get_current_user
 from src.auth.models import User
-from .schemas import UpdateProfileRequest, UserProfileResponse, LinkPhoneRequest, LinkEmailRequest  
+from .schemas import UpdateProfileRequest, UserProfileResponse, LinkPhoneRequest, LinkEmailRequest
 from . import service
 
-router = APIRouter(prefix="/v1/user", tags=["profile"])
+router = APIRouter(prefix="/v1", tags=["profile"])
 
-@router.get("", response_model=UserProfileResponse)
-def get_profile(current_user: User = Depends(get_current_user)):
+@router.get("/user", response_model=UserProfileResponse)
+def get_profile(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    prof = service.get_or_create_profile(db, current_user.id)
     return {
         "email": current_user.email or "",
         "phone": current_user.phone or "",
-        "fileId": current_user.file_id or "",
+        "fileId": prof.file_id or "",
         "fileUri": "",
         "fileThumbnailUri": "",
-        "bankAccountName": getattr(current_user, "bank_account_name", "") or "",
-        "bankAccountHolder": getattr(current_user, "bank_account_holder", "") or "",
-        "bankAccountNumber": getattr(current_user, "bank_account_number", "") or "",
+        "bankAccountName": prof.bank_account_name or "",
+        "bankAccountHolder": prof.bank_account_holder or "",
+        "bankAccountNumber": prof.bank_account_number or "",
     }
 
-@router.put("", response_model=UserProfileResponse)
+@router.put("/user", response_model=UserProfileResponse)
 def update_profile(
     body: UpdateProfileRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    current_user.file_id = (body.fileId or "").strip() or None
-    current_user.bank_account_name = body.bankAccountName
-    current_user.bank_account_holder = body.bankAccountHolder
-    current_user.bank_account_number = body.bankAccountNumber
-
-    db.add(current_user)
-    db.commit()
-    db.refresh(current_user)
-
+    prof = service.update_profile(
+        db, current_user,
+        file_id=body.fileId,
+        bank_name=body.bankAccountName,
+        bank_holder=body.bankAccountHolder,
+        bank_number=body.bankAccountNumber,
+    )
     return {
         "email": current_user.email or "",
         "phone": current_user.phone or "",
-        "fileId": current_user.file_id or "",
+        "fileId": prof.file_id or "",
         "fileUri": "",
         "fileThumbnailUri": "",
-        "bankAccountName": current_user.bank_account_name or "",
-        "bankAccountHolder": current_user.bank_account_holder or "",
-        "bankAccountNumber": current_user.bank_account_number or "",
+        "bankAccountName": prof.bank_account_name or "",
+        "bankAccountHolder": prof.bank_account_holder or "",
+        "bankAccountNumber": prof.bank_account_number or "",
     }
 
-@router.post("/link/phone", response_model=UserProfileResponse, status_code=status.HTTP_200_OK)
-def link_phone(
-    payload: LinkPhoneRequest,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    updated_user = service.link_phone(current_user, payload.phone, db)
+@router.post("/user/link/phone", status_code=status.HTTP_200_OK)
+def link_phone(payload: LinkPhoneRequest, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    user = service.link_phone(current_user, payload.phone, db)
+    prof = service.get_or_create_profile(db, user.id)
     return {
-        "email": updated_user.email or "",
-        "phone": updated_user.phone or "",
-        "fileId": updated_user.file_id or "",
+        "email": user.email or "",
+        "phone": user.phone or "",
+        "fileId": prof.file_id or "",
         "fileUri": "",
         "fileThumbnailUri": "",
-        "bankAccountName": updated_user.bank_account_name or "",
-        "bankAccountHolder": updated_user.bank_account_holder or "",
-        "bankAccountNumber": updated_user.bank_account_number or "",
+        "bankAccountName": prof.bank_account_name or "",
+        "bankAccountHolder": prof.bank_account_holder or "",
+        "bankAccountNumber": prof.bank_account_number or "",
     }
 
-@router.post("/link/email", status_code=status.HTTP_200_OK)
-def link_email(
-    payload: LinkEmailRequest,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    updated_user = service.link_email(current_user, payload.email, db)
+@router.post("/user/link/email", status_code=status.HTTP_200_OK)
+def link_email(payload: LinkEmailRequest, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    user = service.link_email(current_user, payload.email, db)
+    prof = service.get_or_create_profile(db, user.id)
     return {
-        "email": updated_user.email or "",
-        "phone": updated_user.phone or "",
-        "fileId": updated_user.file_id or "",
+        "email": user.email or "",
+        "phone": user.phone or "",
+        "fileId": prof.file_id or "",
         "fileUri": "",
         "fileThumbnailUri": "",
-        "bankAccountName": updated_user.bank_account_name or "",
-        "bankAccountHolder": updated_user.bank_account_holder or "",
-        "bankAccountNumber": updated_user.bank_account_number or "",
+        "bankAccountName": prof.bank_account_name or "",
+        "bankAccountHolder": prof.bank_account_holder or "",
+        "bankAccountNumber": prof.bank_account_number or "",
     }

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -1,0 +1,86 @@
+# src/users/router.py
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.auth.dependencies import get_current_user
+from src.auth.models import User
+from .schemas import UpdateProfileRequest, UserProfileResponse, LinkPhoneRequest, LinkEmailRequest  
+from . import service
+
+router = APIRouter(prefix="/v1/user", tags=["profile"])
+
+@router.get("", response_model=UserProfileResponse)
+def get_profile(current_user: User = Depends(get_current_user)):
+    return {
+        "email": current_user.email or "",
+        "phone": current_user.phone or "",
+        "fileId": current_user.file_id or "",
+        "fileUri": "",
+        "fileThumbnailUri": "",
+        "bankAccountName": getattr(current_user, "bank_account_name", "") or "",
+        "bankAccountHolder": getattr(current_user, "bank_account_holder", "") or "",
+        "bankAccountNumber": getattr(current_user, "bank_account_number", "") or "",
+    }
+
+@router.put("", response_model=UserProfileResponse)
+def update_profile(
+    body: UpdateProfileRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    current_user.file_id = (body.fileId or "").strip() or None
+    current_user.bank_account_name = body.bankAccountName
+    current_user.bank_account_holder = body.bankAccountHolder
+    current_user.bank_account_number = body.bankAccountNumber
+
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
+
+    return {
+        "email": current_user.email or "",
+        "phone": current_user.phone or "",
+        "fileId": current_user.file_id or "",
+        "fileUri": "",
+        "fileThumbnailUri": "",
+        "bankAccountName": current_user.bank_account_name or "",
+        "bankAccountHolder": current_user.bank_account_holder or "",
+        "bankAccountNumber": current_user.bank_account_number or "",
+    }
+
+@router.post("/link/phone", response_model=UserProfileResponse, status_code=status.HTTP_200_OK)
+def link_phone(
+    payload: LinkPhoneRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    updated_user = service.link_phone(current_user, payload.phone, db)
+    return {
+        "email": updated_user.email or "",
+        "phone": updated_user.phone or "",
+        "fileId": updated_user.file_id or "",
+        "fileUri": "",
+        "fileThumbnailUri": "",
+        "bankAccountName": updated_user.bank_account_name or "",
+        "bankAccountHolder": updated_user.bank_account_holder or "",
+        "bankAccountNumber": updated_user.bank_account_number or "",
+    }
+
+@router.post("/link/email", status_code=status.HTTP_200_OK)
+def link_email(
+    payload: LinkEmailRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    updated_user = service.link_email(current_user, payload.email, db)
+    return {
+        "email": updated_user.email or "",
+        "phone": updated_user.phone or "",
+        "fileId": updated_user.file_id or "",
+        "fileUri": "",
+        "fileThumbnailUri": "",
+        "bankAccountName": updated_user.bank_account_name or "",
+        "bankAccountHolder": updated_user.bank_account_holder or "",
+        "bankAccountNumber": updated_user.bank_account_number or "",
+    }

--- a/src/users/schemas.py
+++ b/src/users/schemas.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, constr, Field, EmailStr
+
+class UpdateProfileRequest(BaseModel):
+    fileId: str | None = None
+    bankAccountName: constr(min_length=4, max_length=32)
+    bankAccountHolder: constr(min_length=4, max_length=32)
+    bankAccountNumber: constr(min_length=4, max_length=32)
+
+class UserProfileResponse(BaseModel):
+    email: str = ""
+    phone: str = ""
+    fileId: str = ""
+    fileUri: str = ""            # placeholder
+    fileThumbnailUri: str = ""   # placeholder
+    bankAccountName: str = ""
+    bankAccountHolder: str = ""
+    bankAccountNumber: str = ""
+    
+class LinkPhoneRequest(BaseModel):
+    phone: str = Field(..., pattern=r"^\+[1-9]\d{1,14}$")
+
+
+class LinkEmailRequest(BaseModel):
+    email: EmailStr

--- a/src/users/schemas.py
+++ b/src/users/schemas.py
@@ -1,24 +1,27 @@
-from pydantic import BaseModel, constr, Field, EmailStr
+from pydantic import BaseModel, Field
+from typing import Optional
 
 class UpdateProfileRequest(BaseModel):
-    fileId: str | None = None
-    bankAccountName: constr(min_length=4, max_length=32)
-    bankAccountHolder: constr(min_length=4, max_length=32)
-    bankAccountNumber: constr(min_length=4, max_length=32)
+    fileId: Optional[str] = Field(default=None)
+    bankAccountName: Optional[str] = ""
+    bankAccountHolder: Optional[str] = ""
+    bankAccountNumber: Optional[str] = ""
+
+class LinkPhoneRequest(BaseModel):
+    phone: str = Field(..., pattern=r"^\+[1-9]\d{1,14}$")
+
+class LinkEmailRequest(BaseModel):
+    email: str
 
 class UserProfileResponse(BaseModel):
     email: str = ""
     phone: str = ""
     fileId: str = ""
-    fileUri: str = ""            # placeholder
-    fileThumbnailUri: str = ""   # placeholder
+    fileUri: str = ""
+    fileThumbnailUri: str = ""
     bankAccountName: str = ""
     bankAccountHolder: str = ""
     bankAccountNumber: str = ""
-    
-class LinkPhoneRequest(BaseModel):
-    phone: str = Field(..., pattern=r"^\+[1-9]\d{1,14}$")
 
-
-class LinkEmailRequest(BaseModel):
-    email: EmailStr
+    class Config:
+        from_attributes = True

--- a/src/users/service.py
+++ b/src/users/service.py
@@ -1,62 +1,44 @@
-# src/users/service.py
 from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
-from src.auth import models
+from src.auth import models as auth_models
+from src.users import models as user_models
 
+def get_or_create_profile(db: Session, user_id: str) -> user_models.Profile:
+    prof = db.query(user_models.Profile).filter(user_models.Profile.user_id == user_id).first()
+    if prof:
+        return prof
+    prof = user_models.Profile(user_id=user_id)
+    db.add(prof)
+    db.commit()
+    db.refresh(prof)
+    return prof
 
-def link_phone(user: models.User, phone: str, db: Session) -> models.User:
-    """
-    Link (or relink) a phone number to the current user.
-    Idempotent if the phone is already the user's phone.
-    """
-    phone = (phone or "").strip()
+def update_profile(db: Session, user: auth_models.User, *, file_id: str | None,
+                   bank_name: str | None, bank_holder: str | None, bank_number: str | None) -> user_models.Profile:
+    prof = get_or_create_profile(db, user.id)
+    prof.file_id = (file_id or "").strip() or None
+    prof.bank_account_name = bank_name or ""
+    prof.bank_account_holder = bank_holder or ""
+    prof.bank_account_number = bank_number or ""
+    db.add(prof)
+    db.commit()
+    db.refresh(prof)
+    return prof
 
-    existing = (
-        db.query(models.User)
-        .filter(models.User.phone == phone)
-        .first()
-    )
-    # If someone else already owns this phone -> conflict
+def link_phone(user: auth_models.User, phone: str, db: Session):
+    existing = db.query(auth_models.User).filter(auth_models.User.phone == phone).first()
     if existing and existing.id != user.id:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="phone is taken",
-        )
-
-    # If this user already has the same phone, it's fine (no-op)
-    if user.phone == phone:
-        return user
-
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="phone is taken")
     user.phone = phone
     db.add(user)
     db.commit()
     db.refresh(user)
     return user
 
-
-def link_email(user: models.User, email: str, db: Session) -> models.User:
-    """
-    Link (or relink) an email to the current user.
-    Idempotent if the email is already the user's email.
-    """
-    email = (email or "").strip().lower()  # normalize (optional)
-
-    existing = (
-        db.query(models.User)
-        .filter(models.User.email == email)
-        .first()
-    )
-    # If someone else already owns this email -> conflict
+def link_email(user: auth_models.User, email: str, db: Session):
+    existing = db.query(auth_models.User).filter(auth_models.User.email == email).first()
     if existing and existing.id != user.id:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="email is taken",
-        )
-
-    # No-op if unchanged
-    if user.email == email:
-        return user
-
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="email is taken")
     user.email = email
     db.add(user)
     db.commit()

--- a/src/users/service.py
+++ b/src/users/service.py
@@ -1,0 +1,64 @@
+# src/users/service.py
+from sqlalchemy.orm import Session
+from fastapi import HTTPException, status
+from src.auth import models
+
+
+def link_phone(user: models.User, phone: str, db: Session) -> models.User:
+    """
+    Link (or relink) a phone number to the current user.
+    Idempotent if the phone is already the user's phone.
+    """
+    phone = (phone or "").strip()
+
+    existing = (
+        db.query(models.User)
+        .filter(models.User.phone == phone)
+        .first()
+    )
+    # If someone else already owns this phone -> conflict
+    if existing and existing.id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="phone is taken",
+        )
+
+    # If this user already has the same phone, it's fine (no-op)
+    if user.phone == phone:
+        return user
+
+    user.phone = phone
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def link_email(user: models.User, email: str, db: Session) -> models.User:
+    """
+    Link (or relink) an email to the current user.
+    Idempotent if the email is already the user's email.
+    """
+    email = (email or "").strip().lower()  # normalize (optional)
+
+    existing = (
+        db.query(models.User)
+        .filter(models.User.email == email)
+        .first()
+    )
+    # If someone else already owns this email -> conflict
+    if existing and existing.id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="email is taken",
+        )
+
+    # No-op if unchanged
+    if user.email == email:
+        return user
+
+    user.email = email
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user


### PR DESCRIPTION
## Summary
This PR adds profile management endpoints for TutupLapak API.

### Changes
- GET /v1/user → Get profile data (email, phone, fileId, bank info)
- PUT /v1/user → Update profile (fileId, bank info)
- POST /v1/user/link/phone → Link phone number to account
- POST /v1/user/link/email → Link email to account

### Notes
- `fileUri` and `fileThumbnailUri` are still placeholders (waiting for file upload module)
- Input validation is minimal, additional rules can be added later

### Testing
Tested locally using Swagger UI:
- Successfully retrieved profile with token
- Successfully updated bank account fields
- Properly returned 409 when linking phone/email already used
